### PR TITLE
Load command for clojure

### DIFF
--- a/LoadFileToRepl.sublime-settings
+++ b/LoadFileToRepl.sublime-settings
@@ -19,7 +19,7 @@
 	// either by email: alexey.alekhin@me.com or using issue tracker on github
 	"haskell_load_command" : ":load \"%s\"",
 	  "scala_load_command" : ":load %s",
-	"clojure_load_command" : "(load \"%s\")",
+	"clojure_load_command" : "(load-file \"%s\")",
 	   "ruby_load_command" : "load '%s'",
 	 "python_load_command" : "execfile(\"%s\")",
 	    "lua_load_command" : "dofile(\"%s\")"


### PR DESCRIPTION
I fixed the load command for clojure. (load str) looks in the classpath. (load-file str) looks in the filesystem.
