### PR TITLE
added javascript

### DIFF
--- a/LoadFileToRepl.sublime-settings
+++ b/LoadFileToRepl.sublime-settings
@@ -25,6 +25,7 @@
 	, "lua_load_command"        : "dofile(\"%s\")"
 	, "powershell_load_command" : ". %s"
 	, "sml_load_command"        : "use \"%s\";"
+	, "js_load_command"         : ".load %s"
 
 	// If this options is set to false, keybindings defined by this plugin won't work.
 	// I tried to ommit overlapping with any default keybindings, but anyway,


### PR DESCRIPTION
Hi thanks for building this

I've added a JS load command. I noticed the Node repl doesn't open properly unless a repl is already running. Unlike clojure for example which starts a new repl if one isn't open. I'm guessing it has nothing to do with this PR but thought I should mention it.
