### PR TITLE
Python 3 execfile error

### DIFF
--- a/LoadFileToRepl.sublime-settings
+++ b/LoadFileToRepl.sublime-settings
@@ -15,8 +15,8 @@
 	, "split" : "vertically"
 
 	// Here are all supported language/REPL-specific load commands;
-	// you can edit them (in you User Settings), but if you want to add new, please, write me
-	// either by email: alexey.alekhin@me.com or using issue tracker on github
+	// you can edit them (in you User Settings), but if you want to add a new one, 
+	// please open an issue/pull-request on github
 	, "haskell_load_command"    : ":load \"%s\""
 	, "scala_load_command"      : ":load %s"
 	, "idris_load_command"      : ":load %s"
@@ -24,7 +24,7 @@
 	, "lisp_load_command"    	: "(load \"%s\")"
 	, "scheme_load_command"    	: "(load \"%s\")"
 	, "ruby_load_command"       : "load '%s'"
-	, "python_load_command"     : "execfile(\"%s\")"
+	, "python_load_command"     : "exec(open(\"%s\").read())"
 	, "lua_load_command"        : "dofile(\"%s\")"
 	, "powershell_load_command" : ". %s"
 	, "sml_load_command"        : "use \"%s\";"


### PR DESCRIPTION
I am currently learning python and installed this plugin for sublime3, but when I tried to run my code I was getting this error " NameError: name 'execfile' is not defined. "

I did some googling and saw that execfile is different in python 3 (the version I am learning is 3.4).

I looked at the file " LoadFileToRepl.sublime-settings " in " Load file to REPL.sublime-package " in my installed packages folder.

On line 27 it says , "python_load_command"     : "execfile(\"%s\")" 

I changed this line to , "python_load_command"     : "exec(open(\"%s\").read())"  

This seems to have worked, now I can load my python3 code into the sublimeREPL with this plugin with no errors.
